### PR TITLE
Ensure execute command reads stdin in binary mode

### DIFF
--- a/yt/python/yt/cli/yt_binary.py
+++ b/yt/python/yt/cli/yt_binary.py
@@ -1966,7 +1966,7 @@ def add_remove_member_parser(add_parser):
 def execute(**kwargs):
     if "output_format" not in kwargs["execute_params"]:
         kwargs["execute_params"]["output_format"] = yt.create_format(output_format)
-    data = chunk_iter_stream(sys.stdin, 16 * MB) if "input_format" in kwargs["execute_params"] else None
+    data = chunk_iter_stream(get_binary_std_stream(sys.stdin), 16 * MB) if "input_format" in kwargs["execute_params"] else None
     result = yt.driver.make_request(kwargs["command_name"], kwargs["execute_params"], data=data)
     if result is not None:
         print_to_output(result, eoln=False)

--- a/yt/python/yt/wrapper/tests/test_yt_cli.py
+++ b/yt/python/yt/wrapper/tests/test_yt_cli.py
@@ -537,6 +537,17 @@ class TestYtBinary(object):
         assert not json.loads(response)["value"]
 
     @authors("ilyaibraev")
+    def test_execute_binary_stdin(self, yt_cli: YtCli):
+        file_path = "//home/wrapper_test/binary_file"
+        data = b"\x00\xff\x7f"
+        process = yt_cli.run_in_background([
+            "yt", "execute", "write_file", "{path=\\\"" + file_path + "\\\";input_format=binary}"
+        ])
+        stdout, stderr = process.communicate(input=data)
+        assert process.returncode == 0
+        assert yt_cli.check_output(["yt", "read-file", file_path]) == data
+
+    @authors("ilyaibraev")
     def test_brotli_write(self, yt_cli: YtCli):
         table_path = "//home/wrapper_test/test_table"
         yt_cli.check_output(["yt", "write", table_path, "--format", "dsv", "--config", "{proxy={content_encoding=br}}"], stdin="x=1\nx=2\nx=3\nx=4\n")


### PR DESCRIPTION
## Summary
- Fix yt cli `execute` command to read stdin in binary mode
- Test binary stdin handling via `yt execute write_file`

## Testing
- `pytest yt/python/yt/wrapper/tests/test_yt_cli.py::TestYtBinary::test_execute_binary_stdin -q` *(failed: ModuleNotFoundError: No module named 'yt.packages.requests')*

------
https://chatgpt.com/codex/tasks/task_e_68a0ad9da0b883209ab8728231f5827e