### PR TITLE
yt/server/http_proxy: hide content at creating document

### DIFF
--- a/yt/yt/server/http_proxy/helpers.cpp
+++ b/yt/yt/server/http_proxy/helpers.cpp
@@ -220,6 +220,10 @@ NYTree::IMapNodePtr HideSecretParameters(const TString& commandName, NYTree::IMa
         secretParameters.push_back("/environment");
     }
 
+    if (commandName == "create") {
+        secretParameters.push_back("/attributes/value");
+    }
+
     bool needCleanup = false;
     for (const auto& ypath : secretParameters) {
         if (FindNodeByYPath(parameters, ypath)) {

--- a/yt/yt/server/http_proxy/unittests/helpers_ut.cpp
+++ b/yt/yt/server/http_proxy/unittests/helpers_ut.cpp
@@ -7,10 +7,15 @@
 
 #include <yt/yt/core/misc/error.h>
 
+#include <yt/yt/core/ytree/convert.h>
+#include <yt/yt/core/ytree/fluent.h>
+#include <yt/yt/core/ytree/node.h>
+
 namespace NYT::NHttpProxy {
 namespace {
 
 using namespace NAuth;
+using namespace NYTree;
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -54,6 +59,103 @@ TEST(TTestCsrfTokenTest, Sample)
     auto token = SignCsrfToken("prime", "abcd", now);
     CheckCsrfToken(token, "prime", "abcd", now - TDuration::Minutes(1))
         .ThrowOnError();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+TEST(THideSecretParametersTest, CreateCommandMasksValue)
+{
+    // Test that /attributes/value is masked when commandName == "create"
+    auto original = BuildYsonNodeFluently()
+        .BeginMap()
+            .Item("type").Value("document")
+            .Item("attributes").BeginMap()
+                .Item("value").Value("secret_content_here")
+                .Item("public_field").Value("public_data")
+            .EndMap()
+        .EndMap();
+
+    auto result = HideSecretParameters("create", original->AsMap());
+
+    // Verify the result has the value masked
+    auto maskedValue = FindNodeByYPath(result, "/attributes/value");
+    ASSERT_TRUE(maskedValue);
+    EXPECT_EQ(ConvertTo<TString>(maskedValue), "***");
+
+    // Verify other fields remain unchanged
+    auto publicField = FindNodeByYPath(result, "/attributes/public_field");
+    ASSERT_TRUE(publicField);
+    EXPECT_EQ(ConvertTo<TString>(publicField), "public_data");
+
+    auto typeField = FindNodeByYPath(result, "/type");
+    ASSERT_TRUE(typeField);
+    EXPECT_EQ(ConvertTo<TString>(typeField), "document");
+}
+
+TEST(THideSecretParametersTest, OriginalNodeNotMutated)
+{
+    // Test that the original parameters node is not mutated
+    auto original = BuildYsonNodeFluently()
+        .BeginMap()
+            .Item("attributes").BeginMap()
+                .Item("value").Value("secret_content")
+            .EndMap()
+        .EndMap();
+
+    auto originalPtr = original->AsMap().Get();
+    auto result = HideSecretParameters("create", original->AsMap());
+
+    // Verify original still has the secret value
+    auto originalValue = FindNodeByYPath(original->AsMap(), "/attributes/value");
+    ASSERT_TRUE(originalValue);
+    EXPECT_EQ(ConvertTo<TString>(originalValue), "secret_content");
+
+    // Verify result has masked value
+    auto maskedValue = FindNodeByYPath(result, "/attributes/value");
+    ASSERT_TRUE(maskedValue);
+    EXPECT_EQ(ConvertTo<TString>(maskedValue), "***");
+
+    // Verify result is a different object
+    EXPECT_NE(result.Get(), originalPtr);
+}
+
+TEST(THideSecretParametersTest, NoCloneWhenNoSecrets)
+{
+    // Test that no cloning happens when there are no secret parameters
+    auto original = BuildYsonNodeFluently()
+        .BeginMap()
+            .Item("type").Value("document")
+            .Item("attributes").BeginMap()
+                .Item("public_field").Value("public_data")
+            .EndMap()
+        .EndMap();
+
+    auto originalPtr = original->AsMap().Get();
+    auto result = HideSecretParameters("create", original->AsMap());
+
+    // Verify the same object is returned (no clone)
+    EXPECT_EQ(result.Get(), originalPtr);
+}
+
+TEST(THideSecretParametersTest, NonCreateCommandDoesNotMaskValue)
+{
+    // Test that /attributes/value is not masked for non-create commands
+    auto original = BuildYsonNodeFluently()
+        .BeginMap()
+            .Item("attributes").BeginMap()
+                .Item("value").Value("content_here")
+            .EndMap()
+        .EndMap();
+
+    auto result = HideSecretParameters("get", original->AsMap());
+
+    // Verify the value is not masked (no secret parameters for "get")
+    auto value = FindNodeByYPath(result, "/attributes/value");
+    ASSERT_TRUE(value);
+    EXPECT_EQ(ConvertTo<TString>(value), "content_here");
+
+    // Verify the same object is returned (no clone)
+    EXPECT_EQ(result.Get(), original->AsMap().Get());
 }
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Initial document content is passed as attribute "value",
which should not be logged.

It seems RPC proxy is not affected.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
