### PR TITLE
Add slog-backed core logger

### DIFF
--- a/library/go/core/log/slog/slog.go
+++ b/library/go/core/log/slog/slog.go
@@ -1,0 +1,106 @@
+package slog
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"runtime"
+	"time"
+
+	"go.ytsaurus.tech/library/go/core/log"
+)
+
+const callerSkip = 3
+
+const (
+	LevelTrace = slog.LevelDebug - 4
+	LevelFatal = slog.LevelError + 4
+)
+
+// Logger implements log.Logger interface using standard library slog.Logger.
+type Logger struct {
+	L          *slog.Logger
+	callerSkip int
+}
+
+var _ log.Logger = &Logger{}
+var _ log.Structured = &Logger{}
+var _ log.Fmt = &Logger{}
+var _ log.LoggerWith = &Logger{}
+var _ log.LoggerAddCallerSkip = &Logger{}
+
+// New constructs slog-based logger from provided slog.Logger.
+func New(l *slog.Logger) *Logger {
+	if l == nil {
+		l = slog.Default()
+	}
+	return &Logger{L: l, callerSkip: callerSkip}
+}
+
+// Logger returns general logger.
+func (l *Logger) Logger() log.Logger { return l }
+
+// Fmt returns fmt logger.
+func (l *Logger) Fmt() log.Fmt { return l }
+
+// Structured returns structured logger.
+func (l *Logger) Structured() log.Structured { return l }
+
+// With returns logger that always adds provided key/value to every log entry.
+func (l *Logger) With(fields ...log.Field) log.Logger {
+	return &Logger{L: l.L.With(slogifyFields(fields)...), callerSkip: l.callerSkip}
+}
+
+// AddCallerSkip returns logger that adds caller skip to each log entry.
+func (l *Logger) AddCallerSkip(skip int) log.Logger {
+	return &Logger{L: l.L, callerSkip: l.callerSkip + skip}
+}
+
+// WithName adds name to logger.
+func (l *Logger) WithName(name string) log.Logger {
+	return &Logger{L: l.L.WithGroup(name), callerSkip: l.callerSkip}
+}
+
+func (l *Logger) Trace(msg string, fields ...log.Field) { l.write(LevelTrace, msg, fields...) }
+func (l *Logger) Debug(msg string, fields ...log.Field) { l.write(slog.LevelDebug, msg, fields...) }
+func (l *Logger) Info(msg string, fields ...log.Field)  { l.write(slog.LevelInfo, msg, fields...) }
+func (l *Logger) Warn(msg string, fields ...log.Field)  { l.write(slog.LevelWarn, msg, fields...) }
+func (l *Logger) Error(msg string, fields ...log.Field) { l.write(slog.LevelError, msg, fields...) }
+func (l *Logger) Fatal(msg string, fields ...log.Field) {
+	l.write(LevelFatal, msg, fields...)
+	os.Exit(1)
+}
+
+func (l *Logger) Tracef(format string, args ...interface{}) { l.writef(LevelTrace, format, args...) }
+func (l *Logger) Debugf(format string, args ...interface{}) {
+	l.writef(slog.LevelDebug, format, args...)
+}
+func (l *Logger) Infof(format string, args ...interface{}) { l.writef(slog.LevelInfo, format, args...) }
+func (l *Logger) Warnf(format string, args ...interface{}) { l.writef(slog.LevelWarn, format, args...) }
+func (l *Logger) Errorf(format string, args ...interface{}) {
+	l.writef(slog.LevelError, format, args...)
+}
+func (l *Logger) Fatalf(format string, args ...interface{}) {
+	l.writef(LevelFatal, format, args...)
+	os.Exit(1)
+}
+
+func (l *Logger) writef(level slog.Level, format string, args ...interface{}) {
+	if !l.L.Enabled(context.Background(), level) {
+		return
+	}
+	l.write(level, fmt.Sprintf(format, args...))
+}
+
+func (l *Logger) write(level slog.Level, msg string, fields ...log.Field) {
+	ctx, attrs := slogifyContextAndFields(fields)
+	if !l.L.Enabled(ctx, level) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(l.callerSkip, pcs[:])
+	record := slog.NewRecord(time.Now(), level, msg, pcs[0])
+	record.AddAttrs(attrs...)
+	_ = l.L.Handler().Handle(ctx, record)
+}

--- a/library/go/core/log/slog/slog_test.go
+++ b/library/go/core/log/slog/slog_test.go
@@ -1,0 +1,119 @@
+package slog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"go.ytsaurus.tech/library/go/core/log"
+)
+
+func TestLoggerWritesFields(t *testing.T) {
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: LevelTrace})
+	l := New(slog.New(h))
+
+	l.Info("hello", log.String("string", "value"), log.Int("int", 42), log.Bool("bool", true))
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+	require.Equal(t, "hello", entry["msg"])
+	require.Equal(t, "INFO", entry["level"])
+	require.Equal(t, "value", entry["string"])
+	require.Equal(t, float64(42), entry["int"])
+	require.Equal(t, true, entry["bool"])
+}
+
+func TestWithAndWithName(t *testing.T) {
+	var buf bytes.Buffer
+	l := New(slog.New(slog.NewJSONHandler(&buf, nil)))
+	l = log.With(l, log.String("component", "test")).(*Logger).WithName("group").(*Logger)
+
+	l.Infof("hello %s", "world")
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+	require.Equal(t, "hello world", entry["msg"])
+	require.Equal(t, "test", entry["component"])
+}
+
+func TestTraceAndFatalLevels(t *testing.T) {
+	require.Equal(t, LevelTrace, SlogifyLevel(log.TraceLevel))
+	require.Equal(t, LevelFatal, SlogifyLevel(log.FatalLevel))
+	require.Equal(t, log.TraceLevel, UnslogifyLevel(LevelTrace))
+	require.Equal(t, log.FatalLevel, UnslogifyLevel(LevelFatal))
+}
+
+func TestLazyCallEvaluatedOnlyWhenEnabled(t *testing.T) {
+	var buf bytes.Buffer
+	l := New(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo})))
+
+	called := false
+	l.Debug("debug", log.Lazy("lazy", func() (any, error) {
+		called = true
+		return "value", nil
+	}))
+	require.False(t, called)
+	require.Empty(t, buf.String())
+
+	l.Info("info", log.Lazy("lazy", func() (any, error) {
+		called = true
+		return "value", nil
+	}))
+	require.True(t, called)
+	require.Contains(t, buf.String(), "value")
+}
+
+func TestContextFieldPassedToHandler(t *testing.T) {
+	h := &contextHandler{}
+	l := New(slog.New(h))
+	ctx := context.WithValue(context.Background(), ctxKey{}, "value")
+
+	l.Info("msg", log.Context(ctx), log.String("key", "value"))
+
+	require.Equal(t, "value", h.ctx.Value(ctxKey{}))
+	require.Len(t, h.attrs, 1)
+	require.Equal(t, "key", h.attrs[0].Key)
+}
+
+func TestFieldTypes(t *testing.T) {
+	var buf bytes.Buffer
+	l := New(slog.New(slog.NewJSONHandler(&buf, nil)))
+	now := time.Unix(10, 20).UTC()
+
+	l.Info("msg", log.Time("time", now), log.Duration("duration", time.Second), log.Stringer("stringer", testStringer("stringer value")))
+
+	var entry map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entry))
+	require.Equal(t, now.Format(time.RFC3339Nano), entry["time"])
+	require.Equal(t, float64(time.Second), entry["duration"])
+	require.Equal(t, "stringer value", entry["stringer"])
+}
+
+type ctxKey struct{}
+
+type contextHandler struct {
+	ctx   context.Context
+	attrs []slog.Attr
+}
+
+func (h *contextHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *contextHandler) Handle(ctx context.Context, r slog.Record) error {
+	h.ctx = ctx
+	r.Attrs(func(a slog.Attr) bool {
+		h.attrs = append(h.attrs, a)
+		return true
+	})
+	return nil
+}
+func (h *contextHandler) WithAttrs(attrs []slog.Attr) slog.Handler { return h }
+func (h *contextHandler) WithGroup(name string) slog.Handler       { return h }
+
+type testStringer string
+
+func (s testStringer) String() string { return string(s) }

--- a/library/go/core/log/slog/slogify.go
+++ b/library/go/core/log/slog/slogify.go
@@ -1,0 +1,120 @@
+package slog
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"go.ytsaurus.tech/library/go/core/log"
+)
+
+// SlogifyLevel turns interface log level to slog log level.
+func SlogifyLevel(level log.Level) slog.Level {
+	switch level {
+	case log.TraceLevel:
+		return LevelTrace
+	case log.DebugLevel:
+		return slog.LevelDebug
+	case log.InfoLevel:
+		return slog.LevelInfo
+	case log.WarnLevel:
+		return slog.LevelWarn
+	case log.ErrorLevel:
+		return slog.LevelError
+	case log.FatalLevel:
+		return LevelFatal
+	default:
+		panic(fmt.Sprintf("unknown log level: %d", level))
+	}
+}
+
+// UnslogifyLevel turns slog log level to interface log level.
+func UnslogifyLevel(level slog.Level) log.Level {
+	switch {
+	case level <= LevelTrace:
+		return log.TraceLevel
+	case level < slog.LevelInfo:
+		return log.DebugLevel
+	case level < slog.LevelWarn:
+		return log.InfoLevel
+	case level < slog.LevelError:
+		return log.WarnLevel
+	case level < LevelFatal:
+		return log.ErrorLevel
+	default:
+		return log.FatalLevel
+	}
+}
+
+func slogifyContextAndFields(fields []log.Field) (context.Context, []slog.Attr) {
+	ctx := context.Background()
+	attrs := make([]slog.Attr, 0, len(fields))
+	for _, field := range fields {
+		switch field.Type() {
+		case log.FieldTypeContext:
+			ctx = field.Interface().(context.Context)
+		case log.FieldTypeRawContext, log.FieldTypeSkip:
+			continue
+		default:
+			attrs = append(attrs, slogifyField(field))
+		}
+	}
+	return ctx, attrs
+}
+
+func slogifyFields(fields []log.Field) []any {
+	attrs := make([]any, 0, len(fields))
+	for _, field := range fields {
+		if field.Type() == log.FieldTypeContext || field.Type() == log.FieldTypeRawContext || field.Type() == log.FieldTypeSkip {
+			continue
+		}
+		attrs = append(attrs, slogifyField(field))
+	}
+	return attrs
+}
+
+func slogifyField(field log.Field) slog.Attr {
+	switch field.Type() {
+	case log.FieldTypeNil:
+		return slog.Any(field.Key(), nil)
+	case log.FieldTypeString:
+		return slog.String(field.Key(), field.String())
+	case log.FieldTypeBinary, log.FieldTypeByteString:
+		return slog.Any(field.Key(), field.Binary())
+	case log.FieldTypeBoolean:
+		return slog.Bool(field.Key(), field.Bool())
+	case log.FieldTypeSigned:
+		return slog.Int64(field.Key(), field.Signed())
+	case log.FieldTypeUnsigned:
+		return slog.Uint64(field.Key(), field.Unsigned())
+	case log.FieldTypeFloat:
+		return slog.Float64(field.Key(), field.Float())
+	case log.FieldTypeTime:
+		return slog.Time(field.Key(), field.Time())
+	case log.FieldTypeDuration:
+		return slog.Duration(field.Key(), field.Duration())
+	case log.FieldTypeStringer:
+		return slog.String(field.Key(), field.Interface().(fmt.Stringer).String())
+	case log.FieldTypeLazyCall:
+		return slog.Any(field.Key(), lazyValue{fn: field.Interface()})
+	default:
+		return slog.Any(field.Key(), field.Any())
+	}
+}
+
+type lazyValue struct{ fn any }
+
+func (l lazyValue) LogValue() slog.Value {
+	switch fn := l.fn.(type) {
+	case func() any:
+		return slog.AnyValue(fn())
+	case func() (any, error):
+		v, err := fn()
+		if err != nil {
+			return slog.AnyValue(err)
+		}
+		return slog.AnyValue(v)
+	default:
+		return slog.AnyValue(fn)
+	}
+}

--- a/library/go/core/log/slog/ya.make
+++ b/library/go/core/log/slog/ya.make
@@ -1,0 +1,12 @@
+GO_LIBRARY()
+
+SRCS(
+    slog.go
+    slogify.go
+)
+
+GO_TEST_SRCS(
+    slog_test.go
+)
+
+END()

--- a/library/go/core/log/ya.make
+++ b/library/go/core/log/ya.make
@@ -17,6 +17,7 @@ RECURSE(
     ctxlog
     gotest
     nop
+    slog
     test
     zap
 )


### PR DESCRIPTION
### Motivation
- Provide a `log` backend that uses the standard library `log/slog` so core logging can interoperate with `slog`-based handlers and formats. 
- Support existing core logging features such as structured fields, fmt-style logging, named loggers, caller info and context propagation. 

### Description
- Add a new package `library/go/core/log/slog` with `slog.go`, `slogify.go`, `slog_test.go` and its `ya.make` build file that implements a `Logger` wrapping `*slog.Logger` and satisfying `log.Logger`, `log.Structured`, `log.Fmt`, `log.LoggerWith`, and `log.LoggerAddCallerSkip` interfaces. 
- Implement level mapping with `SlogifyLevel` and `UnslogifyLevel`, and conversion helpers that translate `log.Field` values to `slog.Attr` including `context` extraction and skipping raw fields. 
- Implement lazy evaluation support via a `lazyValue` wrapper for `FieldTypeLazyCall` and ensure lazy evaluators are only invoked when the `slog` handler is enabled. 
- Wire `With`, `WithName`, `AddCallerSkip`, structured/fmt methods, caller frame propagation via `runtime.Callers`, and add unit tests exercising fields, `With`/`WithName`, level conversions, lazy evaluation and context handling. 

### Testing
- Ran `go test ./library/go/core/log/slog` which passed the new package unit tests. 
- Attempted `go test ./...` for the whole module but it failed during dependency download with `Forbidden` from the module proxy (external dependencies such as `github.com/siddontang/go-log`, `github.com/pion/logging`, `github.com/google/go-cmp`, and `go.opentelemetry.io/proto/otlp` could not be fetched). 
- The failures are due to environment package fetch restrictions and are unrelated to the new `slog` package itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a34f190c12883378241efc7043d1593)