### PR TITLE
Document master memory usage estimation

### DIFF
--- a/yt/docs/en/draft/master-architecture-draft-5.md
+++ b/yt/docs/en/draft/master-architecture-draft-5.md
@@ -64,15 +64,59 @@ When a follower's in-flight limits are hit, the leader skips sending new mutatio
 
 A follower in slow mode (after an RPC error or rejection) is sent only one request at a time. If that follower is needed for quorum, every commit waits for a full round-trip to that follower. Watch for log lines `Accept mutations mode is set to slow` — they indicate a follower recovery or network issue.
 
-### Memory
+### Memory { #memory }
 
 The master keeps the entire Cypress tree, all chunk metadata, and all replicated global objects in RAM. Memory usage grows with:
 
 - Number of nodes in Cypress.
 - Number of chunks and replicas.
 - Number of globally replicated objects (accounts, media, etc.) × number of cells.
+- Size of per-object metadata: user attributes, ACLs, schemas, table settings, tablet metadata, locks, and active transaction state.
 
 Monitor `yt_resource_tracker_memory_usage_rss{service="yt-master"}`. Because snapshot creation uses `fork`, the master process must have at least **double** its working-set memory available on the host.
+
+#### Estimating memory by object kind { #memory-by-object-kind }
+
+Use the master RSS metric for the process-level total, then use resource accounting attributes to find which user-visible objects contribute most of the persistent automaton state. The most useful attributes are:
+
+- `@resource_usage/master_memory` — memory charged directly to one object.
+- `@resource_usage/detailed_master_memory` — direct memory split by object kind, for example `nodes`, `chunks`, `attributes`, `tablets`, and `schemas`.
+- `@resource_usage/chunk_host_cell_master_memory` — memory charged on chunk-host cells rather than on the cell that owns the Cypress node.
+- `@recursive_resource_usage` — subtree total, useful for directories and account subtrees.
+- `//sys/accounts/<account>/@recursive_resource_usage` and `//sys/accounts/<account>/@recursive_committed_resource_usage` — totals by account; the committed variant excludes active transactions.
+
+Typical drill-down workflow:
+
+```bash
+# Cluster/process total. Use this for host sizing and snapshot fork headroom.
+yt_resource_tracker_memory_usage_rss{service="yt-master"}
+
+# Account-level ranking.
+yt get //sys/accounts/<account>/@recursive_resource_usage
+yt get //sys/accounts/<account>/@recursive_committed_resource_usage
+
+# Subtree-level ranking.
+yt get //path/to/subtree/@recursive_resource_usage
+
+# Per-object breakdown.
+yt get //path/to/object/@resource_usage
+yt get //path/to/object/@resource_usage/detailed_master_memory
+```
+
+Interpret `detailed_master_memory` as a direction for remediation rather than as an exact replacement for RSS. RSS also includes allocator fragmentation, caches, transient queues, RPC buffers, Hydra mutation backlog, and other process overheads that are not charged to a Cypress object. In a multicell cluster, inspect the same attributes on the native cell that owns the object and remember that globally replicated objects are copied to every master cell.
+
+The fields usually point to the following causes:
+
+| Dominant field | Common cause | How to reduce it |
+|----------------|--------------|------------------|
+| `nodes` | Too many Cypress nodes: tiny files, temporary directories, operation artifacts, many map nodes, many links. | Delete unused subtrees; add TTL/cleanup for `//tmp`-like areas; pack many small items into tables instead of separate Cypress nodes; avoid creating one object per event/job when a table row is enough. |
+| `chunks` or `chunk_host_cell_master_memory` | Too many chunks or replicas: small output chunks, append-heavy tables, unmerged intermediate data, excessive replication factor. | Run merge/auto-merge or rewrite tables with larger chunks; tune writers to produce larger chunks; remove obsolete data; avoid unnecessarily high replication factors; add secondary chunk-host cells when per-cell chunk metadata is the bottleneck. |
+| `attributes` | Large or numerous user attributes, ACLs, annotations, or metadata blobs on many objects. | Move large metadata into table rows or files; keep Cypress attributes small and structured; remove stale custom attributes; avoid storing large opaque JSON/YSON blobs as attributes. |
+| `schemas` | Many distinct large table schemas or repeated schema-like metadata. | Reuse schemas where possible; avoid excessive column counts; remove obsolete tables; avoid duplicating large schema metadata in custom attributes. |
+| `tablets` | Many mounted dynamic-table tablets, especially with rich tablet metadata. | Merge small tablets, reduce tablet count where load allows, unmount or remove unused dynamic tables, and size tablet bundles so tablet metadata growth is intentional. |
+| transaction-related attributes (`locked_node_ids`, `branched_node_ids`, `staged_object_ids`) | Long-lived or very large transactions. | Abort stale transactions; shorten transaction lifetimes; split very large transactions; avoid keeping many locks or staged objects open. |
+
+When shrinking master memory, first remove or merge objects on the heaviest accounts/subtrees, then verify both the charged resources and the process RSS. Charged resources should drop immediately after the corresponding mutations are applied; RSS may decrease more slowly because of allocator behavior and because snapshots, mutation queues, and caches may still hold memory temporarily. Always keep enough free host memory for the next snapshot fork while the cleanup is running.
 
 ### Node registration and disposal
 

--- a/yt/docs/en/draft/master-architecture-draft-5.md
+++ b/yt/docs/en/draft/master-architecture-draft-5.md
@@ -71,7 +71,7 @@ The master keeps the entire Cypress tree, all chunk metadata, and all replicated
 - Number of nodes in Cypress.
 - Number of chunks and replicas.
 - Number of globally replicated objects (accounts, media, etc.) × number of cells.
-- Size of per-object metadata: user attributes, ACLs, schemas, table settings, tablet metadata, locks, and active transaction state.
+- Size of per-object metadata: user attributes, ACLs, schemas, table settings, tablet metadata, locks, active transaction state, and document values.
 
 Monitor `yt_resource_tracker_memory_usage_rss{service="yt-master"}`. Because snapshot creation uses `fork`, the master process must have at least **double** its working-set memory available on the host.
 
@@ -101,9 +101,13 @@ yt get //path/to/subtree/@recursive_resource_usage
 # Per-object breakdown.
 yt get //path/to/object/@resource_usage
 yt get //path/to/object/@resource_usage/detailed_master_memory
+
+# Documents: find candidates, then sample serialized value size carefully.
+yt find //path/to/subtree --type document
+yt get //path/to/document/@value | wc -c
 ```
 
-Interpret `detailed_master_memory` as a direction for remediation rather than as an exact replacement for RSS. RSS also includes allocator fragmentation, caches, transient queues, RPC buffers, Hydra mutation backlog, and other process overheads that are not charged to a Cypress object. In a multicell cluster, inspect the same attributes on the native cell that owns the object and remember that globally replicated objects are copied to every master cell.
+Interpret `detailed_master_memory` as a direction for remediation rather than as an exact replacement for RSS. RSS also includes allocator fragmentation, caches, transient queues, RPC buffers, Hydra mutation backlog, and other process overheads that are not charged to a Cypress object. Document node contents are another important caveat: a document's `@value` is stored in master memory and in snapshots as a YSON tree, but it is not exposed as a separate `detailed_master_memory` category. Estimate it by finding large `document` nodes and inspecting the size of `@value`; treat document payload as master memory even when the charged breakdown points only to the node itself or its attributes. In a multicell cluster, inspect the same attributes on the native cell that owns the object and remember that globally replicated objects are copied to every master cell.
 
 The fields usually point to the following causes:
 
@@ -112,6 +116,7 @@ The fields usually point to the following causes:
 | `nodes` | Too many Cypress nodes: tiny files, temporary directories, operation artifacts, many map nodes, many links. | Delete unused subtrees; add TTL/cleanup for `//tmp`-like areas; pack many small items into tables instead of separate Cypress nodes; avoid creating one object per event/job when a table row is enough. |
 | `chunks` or `chunk_host_cell_master_memory` | Too many chunks or replicas: small output chunks, append-heavy tables, unmerged intermediate data, excessive replication factor. | Run merge/auto-merge or rewrite tables with larger chunks; tune writers to produce larger chunks; remove obsolete data; avoid unnecessarily high replication factors; add secondary chunk-host cells when per-cell chunk metadata is the bottleneck. |
 | `attributes` | Large or numerous user attributes, ACLs, annotations, or metadata blobs on many objects. | Move large metadata into table rows or files; keep Cypress attributes small and structured; remove stale custom attributes; avoid storing large opaque JSON/YSON blobs as attributes. |
+| large `document` node values | YSON document payloads stored directly in the master as part of the node value. They increase RSS and snapshot size even if they are not visible as a dedicated `detailed_master_memory` field. | Keep documents to small configuration/metadata blobs; move large or frequently changed content to Cypress files or tables; delete obsolete documents; avoid using documents as a high-load object database. |
 | `schemas` | Many distinct large table schemas or repeated schema-like metadata. | Reuse schemas where possible; avoid excessive column counts; remove obsolete tables; avoid duplicating large schema metadata in custom attributes. |
 | `tablets` | Many mounted dynamic-table tablets, especially with rich tablet metadata. | Merge small tablets, reduce tablet count where load allows, unmount or remove unused dynamic tables, and size tablet bundles so tablet metadata growth is intentional. |
 | transaction-related attributes (`locked_node_ids`, `branched_node_ids`, `staged_object_ids`) | Long-lived or very large transactions. | Abort stale transactions; shorten transaction lifetimes; split very large transactions; avoid keeping many locks or staged objects open. |

--- a/yt/docs/en/draft/master-architecture-draft-5.md
+++ b/yt/docs/en/draft/master-architecture-draft-5.md
@@ -109,6 +109,19 @@ yt get //path/to/document/@value | wc -c
 
 Interpret `detailed_master_memory` as a direction for remediation rather than as an exact replacement for RSS. RSS also includes allocator fragmentation, caches, transient queues, RPC buffers, Hydra mutation backlog, and other process overheads that are not charged to a Cypress object. Document node contents are another important caveat: a document's `@value` is stored in master memory and in snapshots as a YSON tree, but it is not exposed as a separate `detailed_master_memory` category. Estimate it by finding large `document` nodes and inspecting the size of `@value`; treat document payload as master memory even when the charged breakdown points only to the node itself or its attributes. In a multicell cluster, inspect the same attributes on the native cell that owns the object and remember that globally replicated objects are copied to every master cell.
 
+Use the master Orchid ref-counted tracker when the RSS gap is large or when you suspect memory is held by C++ ref-counted objects rather than by account-charged Cypress resources. It is available under the master monitoring Orchid at `/orchid/monitoring/ref_counted` and reports both totals and per-type rows with `objects_alive`, `objects_allocated`, `bytes_alive`, and `bytes_allocated`:
+
+```bash
+# Total tracked ref-counted objects in one master process.
+curl -s 'http://<master-host>:<monitoring-port>/orchid/monitoring/ref_counted/total'
+
+# Per-type rows; sort locally by bytes_alive to find the largest holders.
+curl -s 'http://<master-host>:<monitoring-port>/orchid/monitoring/ref_counted/statistics' \
+  | jq 'sort_by(.bytes_alive) | reverse | .[:30]'
+```
+
+These Orchid stats are process-local, so query the leader and followers of each master cell when comparing peers or cells. They are not account resource usage and should not be added to `@resource_usage/master_memory`; use them to explain the uncharged part of RSS and to identify broad implementation-level holders such as YSON trees, protobufs, RPC buffers, caches, or other ref-counted helper objects. If the total ref-counted `bytes_alive` grows together with RSS while account `master_memory` stays flat, investigate the largest per-type rows and the corresponding subsystem before looking for user-owned Cypress objects.
+
 The fields usually point to the following causes:
 
 | Dominant field | Common cause | How to reduce it |


### PR DESCRIPTION
### Motivation

- Improve operator guidance for understanding and controlling master process memory by explaining which kinds of objects consume master RAM and how to estimate their contributions. 
- Provide actionable remediation steps for shrinking master memory footprint and avoiding snapshot/fork headroom problems.

### Description

- Added `Size of per-object metadata` to the master memory growth list and a new `Estimating memory by object kind` subsection to `yt/docs/en/draft/master-architecture-draft-5.md` that covers per-object contributions and multicell considerations. 
- Documented the most useful resource-accounting attributes including `@resource_usage/master_memory`, `@resource_usage/detailed_master_memory`, `@resource_usage/chunk_host_cell_master_memory`, `@recursive_resource_usage`, and account-level `@recursive_committed_resource_usage`. 
- Added a concise drill-down workflow with example commands for cluster total, account-level ranking, subtree inspection, and per-object breakdown using `yt get` and the RSS metric `yt_resource_tracker_memory_usage_rss{service="yt-master"}`. 
- Included interpretation guidance for `detailed_master_memory`, a causes-to-remediation table for dominant fields (`nodes`, `chunks`, `attributes`, `schemas`, `tablets`, transaction-related attributes), and operational advice to verify charged resources vs process RSS while keeping snapshot fork headroom.

### Testing

- Ran `git diff --check` to validate the change and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a4deb9cc8448337a239ec668d290da2)