### PR TITLE
Document master cache architecture

### DIFF
--- a/yt/docs/en/draft/master-architecture-draft-4.md
+++ b/yt/docs/en/draft/master-architecture-draft-4.md
@@ -45,8 +45,29 @@ itself in Cypress under `//sys/master_caches/<address>` and exposes a caching
 `ObjectService` for every known master cell. Clients discover these addresses
 through `GetClusterMeta(populate_master_cache_node_addresses=true)`.
 
-Internally the master cache maintains an in-memory SLRU object-service cache
-(default capacity: **1 GB**) keyed by:
+There are two object-service cache levels that use the same cache entry format:
+
+1. **Master-internal cache.** Every master peer owns an in-memory
+   `ObjectService` cache (`/object_service_cache` in master profiling/Orchid)
+   configured by the master's static `object_service/master_cache` section and
+   guarded by the dynamic flag
+   `//sys/@config/object_service/enable_two_level_cache` (default **true**).
+   This level is inside the master process. A request still reaches the master
+   service and performs the normal request-level synchronization, but cache-hit
+   sub-requests are completed from the stored response instead of entering the
+   local-read executor and instead of acquiring an automaton block for reading
+   Cypress state.
+2. **External master-cache process.** A separate `master_cache` server role owns
+   another in-memory `ObjectService` cache and forwards misses to the upstream
+   master. A hit at this level does not contact any master peer at all.
+
+Both levels are important. The master-internal level protects the automaton and
+local-read threads from repeated cacheable reads even when clients talk directly
+to masters. The external level additionally absorbs RPC traffic and
+`SyncWithUpstream` work before it reaches master peers.
+
+Internally each level maintains an in-memory SLRU object-service cache (default
+capacity: **1 GB**) keyed by:
 
 - master cell tag;
 - authenticated user, unless the request disables the per-user cache;
@@ -56,15 +77,16 @@ Internally the master cache maintains an in-memory SLRU object-service cache
 - the `suppress_upstream_sync` and
   `suppress_transaction_coordinator_sync` flags.
 
-Only non-mutating sub-requests without additional attachments are accepted for
-caching. A mutating request, a request without a caching header, or a request
-with unsupported attachments is rejected by the caching service rather than
-being cached accidentally. On a cache miss, the master cache forwards exactly one
-sub-request to the upstream master over a follower channel, stores the response
-together with the response revision and success flag, and then serves waiting
-callers from the stored entry. On a hit, the response is returned directly from
-the master-cache process and the master automaton, local-read executor, and
-`SyncWithUpstream` path are not touched.
+Only non-mutating sub-requests with a caching header are eligible for these
+caches. The external master-cache service additionally rejects requests with
+unsupported attachments rather than caching them accidentally. Mutating requests
+with a caching header fail with a "cannot cache mutating request" error. On a
+cache miss, the master cache forwards exactly one
+sub-request to the upstream master over a follower channel; on a master-internal
+miss, the sub-request continues through the ordinary local-read path. The level
+that executed the miss stores the response together with the response revision
+and success flag, and then serves waiting callers from the stored entry. On a
+hit, the response is returned directly from the cache level that was hit.
 
 ### TTL splitting and stale serving { #master-cache-ttl }
 
@@ -77,10 +99,11 @@ When a master-cache process is used as a second-level cache, it consumes only a
 fraction of the requested TTL locally. The dynamic option
 `//sys/master_caches/@config/caching_object_service/cache_ttl_ratio` defaults to
 `0.5`. For example, with a 20-minute successful-update TTL, the master-cache
-entry is considered fresh for 10 minutes; the forwarded request leaves the
-remaining 10 minutes for the upstream/client-side cache layer. If second-level
-caching is disabled for a request, the local master-cache process uses the full
-TTL.
+entry is considered fresh for 10 minutes; the forwarded request header is
+rewritten with the remaining 10 minutes so the master-internal cache can own the
+rest of the freshness budget. If second-level caching is disabled for a request,
+the local master-cache process uses the full TTL and does not split it with the
+upstream master level.
 
 Expired successful entries may still be returned while a refresh is in flight,
 but only within `success_staleness_bound`. Returning such a stale successful
@@ -91,10 +114,11 @@ stale entries after expiration. A caller can also request a
 evicted and refreshed.
 
 This means cache validation is time/revision based, not invalidation-message
-based: the master cache does not subscribe to every master mutation. A metadata
-change becomes visible through the cache after the relevant cached entry expires,
-after a revision refresh is requested, or after the caller bypasses/suppresses
-the cache according to its read options.
+based: neither the external master-cache process nor the master-internal
+object-service cache subscribes to every master mutation. A metadata change
+becomes visible through the cache after the relevant cached entry expires, after
+a revision refresh is requested, or after the caller bypasses/suppresses the
+cache according to its read options.
 
 ### Serving cluster metadata and cell directories { #master-cache-cluster-meta }
 
@@ -204,6 +228,10 @@ Corner cases to account for:
 - If a master-cache process has stale cell-directory metadata, it may not have
   registered a caching service for a newly added cell yet. Direct master routing
   can work while master-cache routing for the same cell is still unavailable.
+- Disabling or bypassing the external master-cache process does not necessarily
+  disable the master-internal object-service cache. Use
+  `//sys/@config/object_service/enable_two_level_cache` when the goal is to make
+  cacheable requests execute through the ordinary master local-read path.
 - Failed `GetClusterMeta` refreshes use the shorter failed-update TTL and retry
   period, but they do not make an old successful directory magically fresh; a
   component either keeps its last good directory or fails requests that require a

--- a/yt/docs/en/draft/master-architecture-draft-4.md
+++ b/yt/docs/en/draft/master-architecture-draft-4.md
@@ -151,6 +151,84 @@ TTL before the change. Avoid assigning traffic-critical roles and immediately
 assuming every component will route to them; propagation is bounded by the
 synchronizer period plus cache TTL and by retry behavior during failures.
 
+### Related dynamic configs and cluster connection { #master-cache-configs }
+
+There are three different configuration planes involved in this path. They are
+easy to confuse during incidents:
+
+| Plane | Cypress path / source | Main effect | Propagation model |
+|-------|-----------------------|-------------|-------------------|
+| **Master server dynamic config** | `//sys/@config` | Changes behavior of master peers themselves, including multicell role descriptors at `multicell_manager/cell_descriptors/<cell_tag>/roles` and master-side object-service cache behavior. | Applied by master dynamic-config managers; mutations to this document are durable master state, but each option still has its own reconfiguration semantics. |
+| **Master-cache dynamic config** | `//sys/master_caches/@config` | Reconfigures master-cache processes, including `caching_object_service`, `cache_ttl_ratio`, request throttling, cache capacity, and the master-cache process's own `master_cell_directory_synchronizer` override. | Read by master-cache dynamic-config managers; affects master-cache processes, not master peers. |
+| **Cluster connection** | `//sys/@cluster_connection` plus the static cluster connection shipped in component configs | Describes how native clients connect to masters and auxiliary services. Its `secondary_masters` list is the persistent client-side source for master cell addresses; the connection also has dynamic sections for directory synchronizers and other client caches. | Native components consume it through their cluster-directory / connection update policy and through cached `GetClusterMeta` directory refreshes. Some fields are only read when a connection object is created. |
+
+The word "dynamic" in `//sys/@cluster_connection` means "stored in a dynamic
+source" rather than "every field is hot-reloadable". Existing native connection
+objects reconfigure only the fields that have explicit reconfiguration code.
+For example, changing cache sizes, retry periods, and directory-synchronizer
+intervals is generally safe and is expected to take effect after the owning
+component reloads dynamic config. Changing structural connection data such as
+master cell IDs, master addresses, or the `secondary_masters` list should be
+treated as a topology rollout: components must learn the new directory and, for
+some services, may need restart with updated static config.
+
+Safe-to-change examples:
+
+- Lower `master_cell_directory_synchronizer/sync_period` and
+  `expire_after_successful_update_time` before a planned role change, then
+  restore them after all components learn the change.
+- Tune `//sys/master_caches/@config/caching_object_service/cache_ttl_ratio` or
+  cache capacity to trade freshness and memory for upstream master load.
+- Change secondary-cell roles in
+  `//sys/@config/multicell_manager/cell_descriptors/<cell_tag>/roles`, provided
+  you understand that clients with an older cached cell directory may keep using
+  old role information until refresh.
+
+Not safe as an isolated live tweak:
+
+- Removing or reusing a master cell tag/cell ID. Cell tags are embedded in
+  object IDs and must be globally unique.
+- Removing a secondary master from `//sys/@cluster_connection/secondary_masters`
+  while objects, chunks, transactions, portals, or clients can still reference
+  it.
+- Editing an existing table's `external_cell_tag` to move data. Existing chunk
+  trees are not rebalanced by changing this attribute.
+- Relying on a role removal to stop all traffic immediately. Cached directories
+  and already-open channels may keep sending requests until refresh or restart.
+
+Corner cases to account for:
+
+- If a component lowers its synchronizer period but keeps a long successful
+  cache TTL, `GetClusterMeta` may still be served from cache and return the old
+  directory until the TTL expires.
+- If a master-cache process has stale cell-directory metadata, it may not have
+  registered a caching service for a newly added cell yet. Direct master routing
+  can work while master-cache routing for the same cell is still unavailable.
+- Failed `GetClusterMeta` refreshes use the shorter failed-update TTL and retry
+  period, but they do not make an old successful directory magically fresh; a
+  component either keeps its last good directory or fails requests that require a
+  missing cell, depending on the caller and channel policy.
+- During read-only master maintenance, requests that require cross-cell
+  synchronization can fail; avoid combining topology changes with read-only
+  windows unless the procedure explicitly requires it.
+
+To wait for a change to take effect, verify both master state and client-side
+observation:
+
+1. Check the authoritative state on masters, for example
+   `yt get //sys/@registered_master_cell_tags`,
+   `yt get //sys/@dynamically_propagated_masters_cell_tags`, and
+   `yt get //sys/@config/multicell_manager/cell_descriptors/<cell_tag>/roles`.
+2. Force or wait for the master cell directory synchronizer on affected
+   components. Operationally this usually means waiting at least one successful
+   synchronizer cycle after the relevant cache TTL, or temporarily lowering the
+   period/TTL before the rollout.
+3. Confirm that a fresh `GetClusterMeta(populate_cell_directory=true)` from the
+   same route the component uses contains the new cell and roles.
+4. For master-cache routing, also verify that `//sys/master_caches` contains live
+   master-cache instances and use the same master-cache route to perform a
+   cacheable read against the relevant cell.
+
 ### Freshness synchronization (SyncWithUpstream)
 
 Before any local sub-request is executed, the peer must guarantee that it is not

--- a/yt/docs/en/draft/master-architecture-draft-4.md
+++ b/yt/docs/en/draft/master-architecture-draft-4.md
@@ -45,9 +45,23 @@ itself in Cypress under `//sys/master_caches/<address>` and exposes a caching
 `ObjectService` for every known master cell. Clients discover these addresses
 through `GetClusterMeta(populate_master_cache_node_addresses=true)`.
 
-There are two object-service cache levels that use the same cache entry format:
+There are several object-read cache layers that can participate in one native
+read:
 
-1. **Master-internal cache.** Every master peer owns an in-memory
+1. **Native-client object-service cache.** A native connection may create a
+   local `CachingObjectService` and route reads through
+   `EMasterChannelKind::ClientSideCache` (enabled by
+   `TConnectionOptions::EnableClientSideCache`, default **true**). This cache is
+   process-local to the client, proxy, node, scheduler, or other component that
+   owns the connection. It uses the cluster connection's
+   `caching_object_service` settings and forwards misses to the ordinary
+   `Cache` channel, which means the miss goes to an external `master_cache`
+   process when master-cache discovery is available and falls back to a master
+   follower otherwise. A hit at this level does not leave the client process.
+2. **External master-cache process.** A separate `master_cache` server role owns
+   another in-memory `ObjectService` cache and forwards misses to the upstream
+   master. A hit at this level does not contact any master peer at all.
+3. **Master-internal cache.** Every master peer owns an in-memory
    `ObjectService` cache (`/object_service_cache` in master profiling/Orchid)
    configured by the master's static `object_service/master_cache` section and
    guarded by the dynamic flag
@@ -57,17 +71,15 @@ There are two object-service cache levels that use the same cache entry format:
    sub-requests are completed from the stored response instead of entering the
    local-read executor and instead of acquiring an automaton block for reading
    Cypress state.
-2. **External master-cache process.** A separate `master_cache` server role owns
-   another in-memory `ObjectService` cache and forwards misses to the upstream
-   master. A hit at this level does not contact any master peer at all.
 
-Both levels are important. The master-internal level protects the automaton and
-local-read threads from repeated cacheable reads even when clients talk directly
-to masters. The external level additionally absorbs RPC traffic and
-`SyncWithUpstream` work before it reaches master peers.
+All three levels are important. The native-client level removes repeated
+cacheable reads inside long-lived component processes. The external level
+absorbs cross-process RPC traffic and `SyncWithUpstream` work before it reaches
+master peers. The master-internal level protects the automaton and local-read
+threads from repeated cacheable reads even when clients talk directly to masters.
 
-Internally each level maintains an in-memory SLRU object-service cache (default
-capacity: **1 GB**) keyed by:
+Each object-service cache level maintains an in-memory SLRU cache (default
+capacity: **1 GB**, unless overridden in that level's config) keyed by:
 
 - master cell tag;
 - authenticated user, unless the request disables the per-user cache;
@@ -81,12 +93,12 @@ Only non-mutating sub-requests with a caching header are eligible for these
 caches. The external master-cache service additionally rejects requests with
 unsupported attachments rather than caching them accidentally. Mutating requests
 with a caching header fail with a "cannot cache mutating request" error. On a
-cache miss, the master cache forwards exactly one
-sub-request to the upstream master over a follower channel; on a master-internal
-miss, the sub-request continues through the ordinary local-read path. The level
-that executed the miss stores the response together with the response revision
-and success flag, and then serves waiting callers from the stored entry. On a
-hit, the response is returned directly from the cache level that was hit.
+client-side or external-cache miss, that cache forwards exactly one sub-request
+to the next upstream cache/master channel; on a master-internal miss, the
+sub-request continues through the ordinary local-read path. The level that
+executed the miss stores the response together with the response revision and
+success flag, and then serves waiting callers from the stored entry. On a hit,
+the response is returned directly from the cache level that was hit.
 
 ### TTL splitting and stale serving { #master-cache-ttl }
 
@@ -95,15 +107,18 @@ updates (`expire_after_successful_update_time` and
 `expire_after_failed_update_time`) plus an optional
 `success_staleness_bound`.
 
-When a master-cache process is used as a second-level cache, it consumes only a
-fraction of the requested TTL locally. The dynamic option
+When a native-client or master-cache process uses `CachingObjectService`, that
+cache consumes only a fraction of the requested TTL locally before forwarding a
+miss to the next level. The dynamic option
 `//sys/master_caches/@config/caching_object_service/cache_ttl_ratio` defaults to
-`0.5`. For example, with a 20-minute successful-update TTL, the master-cache
-entry is considered fresh for 10 minutes; the forwarded request header is
-rewritten with the remaining 10 minutes so the master-internal cache can own the
-rest of the freshness budget. If second-level caching is disabled for a request,
-the local master-cache process uses the full TTL and does not split it with the
-upstream master level.
+`0.5` for external master-cache processes; the native-client cache uses the
+`caching_object_service` configuration embedded in its cluster connection. For
+example, with a 20-minute successful-update TTL and a 0.5 ratio, the current
+cache level considers its entry fresh for 10 minutes; the forwarded request
+header is rewritten with the remaining 10 minutes so upstream cache levels can
+own the rest of the freshness budget. If second-level caching is disabled for a
+request, the current `CachingObjectService` uses the full TTL and does not split
+it with the upstream level.
 
 Expired successful entries may still be returned while a refresh is in flight,
 but only within `success_staleness_bound`. Returning such a stale successful
@@ -114,11 +129,51 @@ stale entries after expiration. A caller can also request a
 evicted and refreshed.
 
 This means cache validation is time/revision based, not invalidation-message
-based: neither the external master-cache process nor the master-internal
-object-service cache subscribes to every master mutation. A metadata change
-becomes visible through the cache after the relevant cached entry expires, after
-a revision refresh is requested, or after the caller bypasses/suppresses the
-cache according to its read options.
+based: native-client caches, external master-cache processes, and the
+master-internal object-service cache do not subscribe to every master mutation.
+A metadata change becomes visible through the cache after the relevant cached
+entry expires, after a revision refresh is requested, or after the caller
+bypasses/suppresses the cache according to its read options.
+
+### Native-client object and attribute caches { #native-client-object-cache }
+
+The native-client object-service cache described above is transparent for
+ordinary YPath reads that use `TMasterReadOptions` and choose
+`ReadFrom = ClientSideCache` (or a higher-level helper that does so). If the
+connection was created with `EnableClientSideCache = false`, the requested
+`ClientSideCache` channel is downgraded to the `Cache` channel; if no external
+master cache is configured or discovered, `Cache` is downgraded to a follower
+master channel. Thus disabling client-side cache removes only the local
+per-connection cache; it does not by itself disable the external master-cache
+process or the master-internal cache.
+
+Some native components also build **object attribute caches** on top of YPath
+reads. `TObjectAttributeCache` stores parsed attribute dictionaries by Cypress
+path and fetches misses via `TBatchAttributeFetcher`, which sends batched
+`get <path>/@` or `list <dir>/@` requests with the same `TMasterReadOptions`.
+This means one logical attribute lookup may be cached twice:
+
+1. in the component's object attribute cache, keyed by the cache's logical
+   object key/path and governed by its `TAsyncExpiringCacheConfig`
+   (`expire_after_access_time`, `expire_after_successful_update_time`, and
+   `expire_after_failed_update_time`);
+2. in one or more object-service cache levels underneath, keyed by the YPath
+   request and governed by the request's master-read TTLs.
+
+Invalidating the object attribute cache only removes or refreshes that
+component-local parsed value. For caches that support
+`InvalidateActiveAndSetRefreshRevision`, the cache records a minimum
+`refresh_revision` for the path, and the next fetch passes that revision down in
+the caching header so lower object-service cache levels must refresh entries
+that are not newer. Caches that do not pass a refresh revision rely on their own
+expiration time plus the lower object-service TTLs.
+
+Operationally, if an object attribute change must be observed immediately by a
+long-lived native component, check all relevant layers: invalidate or wait out
+the component's attribute cache, ensure the read is not served by the
+client-side object-service cache, and account for external/master-internal cache
+TTLs unless the caller uses a refresh revision or bypasses cacheable master-read
+options.
 
 ### Serving cluster metadata and cell directories { #master-cache-cluster-meta }
 
@@ -184,7 +239,7 @@ easy to confuse during incidents:
 |-------|-----------------------|-------------|-------------------|
 | **Master server dynamic config** | `//sys/@config` | Changes behavior of master peers themselves, including multicell role descriptors at `multicell_manager/cell_descriptors/<cell_tag>/roles` and master-side object-service cache behavior. | Applied by master dynamic-config managers; mutations to this document are durable master state, but each option still has its own reconfiguration semantics. |
 | **Master-cache dynamic config** | `//sys/master_caches/@config` | Reconfigures master-cache processes, including `caching_object_service`, `cache_ttl_ratio`, request throttling, cache capacity, and the master-cache process's own `master_cell_directory_synchronizer` override. | Read by master-cache dynamic-config managers; affects master-cache processes, not master peers. |
-| **Cluster connection** | `//sys/@cluster_connection` plus the static cluster connection shipped in component configs | Describes how native clients connect to masters and auxiliary services. Its `secondary_masters` list is the persistent client-side source for master cell addresses; the connection also has dynamic sections for directory synchronizers and other client caches. | Native components consume it through their cluster-directory / connection update policy and through cached `GetClusterMeta` directory refreshes. Some fields are only read when a connection object is created. |
+| **Cluster connection** | `//sys/@cluster_connection` plus the static cluster connection shipped in component configs | Describes how native clients connect to masters and auxiliary services. Its `secondary_masters` list is the persistent client-side source for master cell addresses; it also carries `caching_object_service` settings for native-client object-service caches and dynamic sections for directory synchronizers and other client caches. | Native components consume it through their cluster-directory / connection update policy and through cached `GetClusterMeta` directory refreshes. Some fields are only read when a connection object is created. |
 
 The word "dynamic" in `//sys/@cluster_connection` means "stored in a dynamic
 source" rather than "every field is hot-reloadable". Existing native connection
@@ -228,10 +283,12 @@ Corner cases to account for:
 - If a master-cache process has stale cell-directory metadata, it may not have
   registered a caching service for a newly added cell yet. Direct master routing
   can work while master-cache routing for the same cell is still unavailable.
-- Disabling or bypassing the external master-cache process does not necessarily
-  disable the master-internal object-service cache. Use
-  `//sys/@config/object_service/enable_two_level_cache` when the goal is to make
-  cacheable requests execute through the ordinary master local-read path.
+- Disabling or bypassing one cache layer does not necessarily disable the
+  others. `EnableClientSideCache = false` bypasses only the native connection's
+  local object-service cache; disabling external master-cache discovery bypasses
+  only the separate `master_cache` process; use
+  `//sys/@config/object_service/enable_two_level_cache` for the master-internal
+  object-service cache.
 - Failed `GetClusterMeta` refreshes use the shorter failed-update TTL and retry
   period, but they do not make an old successful directory magically fresh; a
   component either keeps its last good directory or fails requests that require a

--- a/yt/docs/en/draft/master-architecture-draft-4.md
+++ b/yt/docs/en/draft/master-architecture-draft-4.md
@@ -36,6 +36,121 @@ sub-request is classified independently:
 | **Remote** | Target path belongs to another cell (cross-cell). | Forwarded via RPC to the target cell's object service. |
 | **Cache** | Non-mutating, response found in the two-level master cache. | Answered immediately without touching the automaton. |
 
+## Master cache and cached cluster metadata { #master-cache }
+
+The master cache is a separate server role that fronts the master's
+`ObjectService` for cacheable, non-mutating reads. It is not a Hydra peer and it
+does not own durable master state. Instead, each master-cache process registers
+itself in Cypress under `//sys/master_caches/<address>` and exposes a caching
+`ObjectService` for every known master cell. Clients discover these addresses
+through `GetClusterMeta(populate_master_cache_node_addresses=true)`.
+
+Internally the master cache maintains an in-memory SLRU object-service cache
+(default capacity: **1 GB**) keyed by:
+
+- master cell tag;
+- authenticated user, unless the request disables the per-user cache;
+- target path;
+- service and method;
+- request body;
+- the `suppress_upstream_sync` and
+  `suppress_transaction_coordinator_sync` flags.
+
+Only non-mutating sub-requests without additional attachments are accepted for
+caching. A mutating request, a request without a caching header, or a request
+with unsupported attachments is rejected by the caching service rather than
+being cached accidentally. On a cache miss, the master cache forwards exactly one
+sub-request to the upstream master over a follower channel, stores the response
+together with the response revision and success flag, and then serves waiting
+callers from the stored entry. On a hit, the response is returned directly from
+the master-cache process and the master automaton, local-read executor, and
+`SyncWithUpstream` path are not touched.
+
+### TTL splitting and stale serving { #master-cache-ttl }
+
+The request's caching header carries separate TTLs for successful and failed
+updates (`expire_after_successful_update_time` and
+`expire_after_failed_update_time`) plus an optional
+`success_staleness_bound`.
+
+When a master-cache process is used as a second-level cache, it consumes only a
+fraction of the requested TTL locally. The dynamic option
+`//sys/master_caches/@config/caching_object_service/cache_ttl_ratio` defaults to
+`0.5`. For example, with a 20-minute successful-update TTL, the master-cache
+entry is considered fresh for 10 minutes; the forwarded request leaves the
+remaining 10 minutes for the upstream/client-side cache layer. If second-level
+caching is disabled for a request, the local master-cache process uses the full
+TTL.
+
+Expired successful entries may still be returned while a refresh is in flight,
+but only within `success_staleness_bound`. Returning such a stale successful
+entry also forces the upper cache layer's staleness bound to zero, so stale data
+is not compounded across multiple cache levels. Failed entries are not served as
+stale entries after expiration. A caller can also request a
+`refresh_revision`; an entry with a revision not newer than this value is
+evicted and refreshed.
+
+This means cache validation is time/revision based, not invalidation-message
+based: the master cache does not subscribe to every master mutation. A metadata
+change becomes visible through the cache after the relevant cached entry expires,
+after a revision refresh is requested, or after the caller bypasses/suppresses
+the cache according to its read options.
+
+### Serving cluster metadata and cell directories { #master-cache-cluster-meta }
+
+Several components periodically call `GetClusterMeta` through the cache path to
+populate process-local cluster metadata:
+
+- node, cluster, medium, user, and feature directories;
+- timestamp-provider and master-cache node addresses;
+- the **master cell directory**, including primary and secondary master
+  connection configs and per-cell roles.
+
+For the master cell directory specifically, the native connection owns a master
+cell directory synchronizer. It periodically sends
+`GetClusterMeta(populate_cell_directory=true)` through a cache channel to the
+primary master. Defaults are:
+
+- sync period: **60 minutes**;
+- retry period after a failed sync: **15 seconds**;
+- cache TTL for a successful update: **20 minutes**;
+- cache TTL for a failed update: **15 seconds**.
+
+The primary master builds the cell directory from the multicell manager's master
+cell connection configs and current roles. Each master-cache process subscribes
+to directory changes in its own native connection; when a new secondary master
+cell appears in that directory, it registers an additional caching
+`ObjectService` for the new cell. Disappearing cells are treated as an alert,
+not as an ordinary cache eviction path.
+
+### Operational effect on adding cells and changing roles { #master-cache-cell-changes }
+
+Adding a secondary master cell or changing a cell's roles is committed on the
+masters first, but proxies, nodes, schedulers, master caches, and other native
+clients can continue using their cached master cell directory until their
+synchronizer refreshes it or an explicit sync is forced. The visible effects are:
+
+- A newly added master cell is not routable through a given component until that
+  component has learned the new cell directory entry.
+- New roles such as `chunk_host`, `cypress_node_host`, or
+  `transaction_coordinator` are not used for automatic placement or coordinator
+  selection by a component that still holds an older cell directory.
+- If roles are changed and the old cached directory says a cell is eligible for
+  some role, clients may continue trying that role until their directory cache
+  expires or synchronizes.
+- Master-cache processes that have not yet synchronized the new directory do not
+  expose a caching service realm for the new cell, so requests that rely on
+  master-cache routing to that cell can miss the new cache layer or fail over to
+  another route depending on the caller's channel policy.
+
+For planned cell addition or role changes, treat the master cell directory cache
+as part of the rollout. After committing the topology or role change, wait for
+`GetClusterMeta`/master-cell-directory synchronizers to complete on the affected
+components, or temporarily reduce the synchronizer period and successful-update
+TTL before the change. Avoid assigning traffic-critical roles and immediately
+assuming every component will route to them; propagation is bounded by the
+synchronizer period plus cache TTL and by retry behavior during failures.
+
 ### Freshness synchronization (SyncWithUpstream)
 
 Before any local sub-request is executed, the peer must guarantee that it is not

--- a/yt/docs/en/draft/master-architecture-draft-5.md
+++ b/yt/docs/en/draft/master-architecture-draft-5.md
@@ -186,6 +186,16 @@ yt set //sys/@config/multicell_manager/cell_descriptors/<cell_tag>/roles '[chunk
 
 If no explicit roles are assigned, a secondary cell may still receive the default `cypress_node_host | chunk_host` roles unless `remove_secondary_cell_default_roles` is enabled or the cell is dynamically propagated. Assign roles explicitly to control what work the new cell serves after addition.
 
+After adding cells or changing roles, remember that non-master components learn
+the master cell directory through cached `GetClusterMeta` responses. Proxies,
+nodes, schedulers, and master-cache processes may keep an older view until their
+master-cell-directory synchronizer refreshes it (60-minute default sync period,
+20-minute default successful-update TTL). For traffic-critical role changes,
+wait for directory synchronization or temporarily shorten these intervals before
+expecting all clients to route to the new roles. See
+[Master cache and cached cluster metadata](./master-architecture-draft-4.md#master-cache)
+for the cache and validation details.
+
 ### Scaling recommendations
 
 A single-cell master setup is sufficient for most clusters. Consider adding secondary chunk-host cells when:

--- a/yt/docs/en/draft/master-architecture-draft-5.md
+++ b/yt/docs/en/draft/master-architecture-draft-5.md
@@ -196,6 +196,14 @@ expecting all clients to route to the new roles. See
 [Master cache and cached cluster metadata](./master-architecture-draft-4.md#master-cache)
 for the cache and validation details.
 
+Treat `//sys/@cluster_connection/secondary_masters` and master static configs as
+the topology source for clients, not as a low-risk runtime tuning knob. Adding
+cells must append new entries; do not remove or rewrite existing cell IDs/tags
+unless you are following a dedicated recovery procedure. Before relying on a
+newly assigned role, check the authoritative master-side role descriptor and then
+verify the same role through a fresh `GetClusterMeta(populate_cell_directory=true)`
+request from the route used by the affected components.
+
 ### Scaling recommendations
 
 A single-cell master setup is sufficient for most clusters. Consider adding secondary chunk-host cells when:


### PR DESCRIPTION
### Motivation

- Describe how the separate master-cache role fronts the master's `ObjectService` for cacheable, non-mutating reads and how it affects read paths and master load. 
- Explain cache validation, TTL splitting and stale-serving semantics used by the two-level cache design. 
- Document how cached `GetClusterMeta` responses populate process-local cluster metadata including the master cell directory. 
- Clarify operational effects when adding new master cells or changing cell roles because non-master components use a cached cell directory.

### Description

- Added a new section `Master cache and cached cluster metadata` to `yt/docs/en/draft/master-architecture-draft-4.md` describing the master-cache server role, registration path (`//sys/master_caches/<address>`), discovery via `GetClusterMeta(populate_master_cache_node_addresses=true)`, cache key components, and that hits avoid the automaton and `SyncWithUpstream` path. 
- Documented TTL splitting behavior and stale-serving rules, including the dynamic `cache_ttl_ratio` (`//sys/master_caches/@config/caching_object_service/cache_ttl_ratio`, default `0.5`), separate TTLs for successful/failed updates, `success_staleness_bound`, and `refresh_revision` semantics. 
- Documented what cluster metadata is fetched via cached `GetClusterMeta` (node/cluster/medium/user/feature directories, master cell directory, timestamp-provider and master-cache addresses) and the master-cell-directory synchronizer defaults (sync period `60m`, retry `15s`, successful-update TTL `20m`, failed-update TTL `15s`). 
- Updated `yt/docs/en/draft/master-architecture-draft-5.md` to cross-link and warn operators that proxies, nodes, schedulers, and master-cache processes learn new cells/roles through cached `GetClusterMeta` responses and therefore may continue using an older directory until their synchronizer refreshes, with guidance to wait for synchronization or temporarily shorten sync/TTL for rollouts.

### Testing

- Ran `git diff --check` to validate patch formatting and found no issues. 
- Verified the documentation files were updated and committed (`Document master cache architecture`), and confirmed repository status with `git status --short`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a5097f0ed508337b2d7a83156f8c93f)