### PR TITLE
Fix Hydra read-only snapshot state transition

### DIFF
--- a/yt/yt/server/lib/hydra/distributed_hydra_manager.cpp
+++ b/yt/yt/server/lib/hydra/distributed_hydra_manager.cpp
@@ -2936,8 +2936,14 @@ private:
 
         YT_VERIFY(value ||
             ControlState_ == EPeerState::LeaderRecovery ||
-            ControlState_ == EPeerState::FollowerRecovery);
+            ControlState_ == EPeerState::FollowerRecovery ||
+            ControlState_ == EPeerState::Following);
 
+        // A follower may receive a regular (non-read-only) snapshot request after
+        // it has already completed recovery from a read-only snapshot. In this
+        // case the request is a part of the leader-to-follower replication flow,
+        // so the control epoch read-only flag must follow the snapshot metadata
+        // instead of crashing on the state transition.
         ControlEpochContext_->ReadOnly = value;
 
         YT_LOG_INFO("Read-only mode %v", value ? "enabled" : "disabled");


### PR DESCRIPTION
### Motivation
- Prevent a master crash caused by `YT_VERIFY` in `SetReadOnly` when a follower that completed recovery (`Following`) receives a regular (non-read-only) snapshot from the leader and must clear the read-only flag.

### Description
- Permit clearing the control-epoch read-only flag from `Following` by adding `EPeerState::Following` to the allowed states in `SetReadOnly` and document the follower-after-recovery snapshot case in `yt/yt/server/lib/hydra/distributed_hydra_manager.cpp`.

### Testing
- Ran `git diff --check` which produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a58c5bca06c83379cd97c1af2c72d01)